### PR TITLE
Link rule documentation url in diagnostics

### DIFF
--- a/src/ameba-ls/ameba/diagnostics_formatter.cr
+++ b/src/ameba-ls/ameba/diagnostics_formatter.cr
@@ -22,7 +22,11 @@ class AmebaLS::DiagnosticsFormatter < Ameba::Formatter::BaseFormatter
       )
 
       diagnostics << LSProtocol::Diagnostic.new(
-        message: "[#{issue.rule.name}] #{issue.message}",
+        code: issue.rule.name,
+        code_description: LSProtocol::CodeDescription.new(
+          href: URI.parse(issue.rule.class.documentation_url),
+        ),
+        message: issue.message,
         range: LSProtocol::Range.new(
           start: start_location,
           end: end_location,


### PR DESCRIPTION
### Before

<img width="476" height="73" src="https://github.com/user-attachments/assets/0b465338-1176-493d-b544-36a9daf96e69" />

### After

<img width="475" height="73" src="https://github.com/user-attachments/assets/13ff3afb-3e5d-436d-ae42-0d9a5ccca720" />
