### PR TITLE
Fix mismatch between issues and diagnostics

### DIFF
--- a/src/ameba-ls/larimar/provider.cr
+++ b/src/ameba-ls/larimar/provider.cr
@@ -58,7 +58,7 @@ class AmebaLS::Provider < Larimar::Provider
     rescue CancellationException
     end
 
-    @issues[document.uri] = source.issues
+    @issues[document.uri] = source.issues.reject(&.disabled?)
     @diagnostics[document.uri] = formatter.diagnostics
 
     publish_diagnostics(document, formatter.diagnostics)


### PR DESCRIPTION
```cr
# ameba:disable Style/CallParentheses
%w[].index 42 # <- invoking code actions on this line would incorrectly show "Fix Style/CallParentheses" QuickFix code action
%w[].select(&.is_a?(String))
```

Fixes regression introduced in f047d83bdfc63b39133b3d4aaef7db9f940818cc